### PR TITLE
Fix paperlog-web versioning

### DIFF
--- a/packages/paperlog-web/package.json
+++ b/packages/paperlog-web/package.json
@@ -36,5 +36,5 @@
     "types:check": "tsc -noEmit",
     "clean": "rm -rf dist"
   },
-  "version": null
+  "version": "0.0.1"
 }


### PR DESCRIPTION
The intent is for this package to not be released, but setting the
version to null was creating odd entries in it's changelog

Having `private` set to true in paperlog-web's `package.json` is
all that is needed