### PR TITLE
Fix pnpm changing lock in dev mode

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,2 @@
 packages:
-  - "packages/**"
+  - "packages/*"


### PR DESCRIPTION
When a copy of the app was built, there was an additional package.json
in `packages/paperlog-cli/dist` which pnpm was seeing.
Now with recursion removed this no longer occurs